### PR TITLE
Pull Request to fix compatibility with latest M2.3 and bugfix

### DIFF
--- a/Model/NewsletterSubscriptionManagement.php
+++ b/Model/NewsletterSubscriptionManagement.php
@@ -6,6 +6,7 @@
 
 namespace Staempfli\CheckoutNewsletterSubscription\Model;
 
+use Magento\Quote\Model\ResourceModel\Quote\QuoteIdMask;
 use Staempfli\CheckoutNewsletterSubscription\Api\Data\NewsletterSubscriptionInterface;
 use Staempfli\CheckoutNewsletterSubscription\Api\NewsletterSubscriptionManagementInterface;
 use Staempfli\CheckoutNewsletterSubscription\Model\Data\NewsletterSubscription;
@@ -23,13 +24,19 @@ class NewsletterSubscriptionManagement implements NewsletterSubscriptionManageme
      * @var QuoteIdMaskFactory
      */
     private $quoteIdMaskFactory;
+    /**
+     * @var QuoteIdMask
+     */
+    private $quoteIdMaskResourceModel;
 
     public function __construct(
+        QuoteIdMask $quoteIdMaskResourceModel,
         CartRepositoryInterface $cartRepository,
         QuoteIdMaskFactory $quoteIdMaskFactory
     ) {
         $this->cartRepository = $cartRepository;
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
+        $this->quoteIdMaskResourceModel = $quoteIdMaskResourceModel;
     }
 
     /**
@@ -63,7 +70,8 @@ class NewsletterSubscriptionManagement implements NewsletterSubscriptionManageme
         try {
             return $this->cartRepository->getActive($cartId);
         } catch (\Exception $e) {
-            $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+            $quoteIdMask = $this->quoteIdMaskFactory->create();
+            $this->quoteIdMaskResourceModel->load($quoteIdMask, $cartId, 'masked_id');
             return $this->cartRepository->getActive($quoteIdMask->getQuoteId());
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -2,12 +2,12 @@
   "name": "staempfli/magento2-module-checkout-newsletter-subscription",
   "description": "Magento 2 Checkout Newsletter Subscription",
   "require": {
-    "php": "^7.0|^7.1",
-    "magento/module-webapi": "~100.1|~100.2",
-    "magento/module-checkout": "~100.1|~100.2",
-    "magento/module-newsletter": "~100.1|~100.2",
+    "php": "^7.0|^7.1|^7.2",
+    "magento/module-webapi": "~100.1|~100.2|~100.3",
+    "magento/module-checkout": "~100.1|~100.2|~100.3",
+    "magento/module-newsletter": "~100.1|~100.2|~100.3",
     "magento/module-quote": "~100.1|~101.0",
-    "magento/framework": "~100.1|~101.0"
+    "magento/framework": "~100.1|~101.0|~102.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~6.2.0",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "staempfli/magento2-module-checkout-newsletter-subscription",
   "description": "Magento 2 Checkout Newsletter Subscription",
+  "version": "1.1",
   "require": {
     "php": "^7.0|^7.1|^7.2",
     "magento/module-webapi": "~100.1|~100.2|~100.3",

--- a/view/frontend/web/js/model/newsletter-validator.js
+++ b/view/frontend/web/js/model/newsletter-validator.js
@@ -11,10 +11,22 @@ define(
     function ($, customer, quote, urlBuilder, errorProcessor, urlFormatter) {
         'use strict';
 
+        function getNewsletterSubscribtionStatus() {
+            var contexts = document.querySelectorAll('[type=radio]');
+            var i;
+            for (i = 0; i < contexts.length; i++) {
+                var checkbox = document.querySelector('#newsletter_' + contexts[i].id);
+                if (checkbox && checkbox.checked) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         return {
             validate: function () {
                 var isCustomer = customer.isLoggedIn();
-                var status = $('#newsletter-subscription').is(':checked');
+                var status = getNewsletterSubscribtionStatus();
                 var quoteId = quote.getQuoteId();
                 var url;
 

--- a/view/frontend/web/js/view/newsletter.js
+++ b/view/frontend/web/js/view/newsletter.js
@@ -4,9 +4,33 @@ define([
     'uiComponent'
 ], function (ko, $, Component) {
     'use strict';
+
+    function getContextId(element) {
+        var context = element;
+        while (!context.querySelector('[type=radio]')) {
+            context = context.parentNode;
+        }
+        return context.querySelector('[type=radio]').id
+    }
+
     return Component.extend({
         defaults: {
             template: 'Staempfli_CheckoutNewsletterSubscription/newsletter'
+        },
+
+        /**
+         * @param {Object} context - the ko context
+         */
+        getCheckboxId: function (context) {
+            return 'newsletter_' + getContextId(context);
+        },
+
+        /**
+         * @param {Object} context - the ko context
+         */
+        getCheckboxName: function (context) {
+
+            return 'newsletter[' + getContextId(context) + ']';
         }
     });
 });

--- a/view/frontend/web/template/newsletter.html
+++ b/view/frontend/web/template/newsletter.html
@@ -1,8 +1,9 @@
 <div class="payment-option opc-payment-additional newsletter last">
     <form class="form newsletter-subscription-form">
         <div class="payment-option-inner">
-            <input type="checkbox" id="newsletter-subscription" name='newsletter-subscription'/>
-            <label for="newsletter-subscription">
+            <input type="checkbox"
+                   data-bind="attr: { 'id': getCheckboxId($element), 'name': getCheckboxName($element) }"/>
+            <label data-bind="attr: {'for': getCheckboxId($element)}">
                 <span data-bind="i18n: 'Yes, I would like to receive regular news and offers.'"></span>
             </label>
         </div>


### PR DESCRIPTION
### Description
It seem to be that the module already support M2.3 and PHP 7.2, so I updated only the requirement in the composer.json. I have tested with M2.3.1 and PHP 7.2.18.

### Fixed Bug
1. Remove the deprecated method load on the model and use instead the same method on the ResourceModel
2. Fix the duplicated newsletter checkbox id in the checkout when there are more than one payment method

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages